### PR TITLE
Replace double pipes with html encoding

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -64,6 +64,9 @@ let js = (clazz, title, code, icon) => {
         /((?:^|\s)\/\/[^\n]*)/g,
         "<span class=comment>$1</span>")
     code = code.replace(
+        /\|\|/g,
+        "<code>&#124&#124</code>")
+    code = code.replace(
         /\|(.+?)\|/g,
         "<span class=mark>$1</span>")
     code = code.replace(/@3@/g, "|");
@@ -139,4 +142,3 @@ tmpl = tmpl.replace(/%BODY%/, out).replace(/%NAV%/, nav)
 
 /*  write the resulting HTML page  */
 fs.writeFileSync("index.html", tmpl, "utf8")
-


### PR DESCRIPTION
This commit fixed the wrong syntax-highlighting of double pipes characters (`||`). Consider the [NumberSignDetermination](http://es6-features.org/#NumberSignDetermination) section:

``` javascript
function |mathSign| (x) {
     return |((x === 0 || isNaN(x)) ? x : (x > 0 ? 1 : -1))|;
}
```

This is currently interpreted as two separate chunks; `|((x === 0 |` and `| isNaN(x)) ? x : (x > 0 ? 1 : -1))|`:

``` javascript
function mathSign (x) {
    return ((x === 0  isNaN(x)) ? x : (x > 0 ? 1 : -1)); // Double pipes have gone
}
```

So, I replaced the `||` with `<code>&#124&#124</code>` before interpreting any pipe character.
