### PR TITLE
Fix ES5 Generator Function, Iterator Protocol example

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -1008,7 +1008,7 @@ order to produce sequence of values (either finite or infinite).
 6| }
 
 5| var fibonacci = {
-5|     next: ((|function| () {
+5|     next: (|function| () {
 5|         var pre = 0, cur = 1;
 5|         return function () {
 5|             tmp = pre;
@@ -1016,7 +1016,7 @@ order to produce sequence of values (either finite or infinite).
 5|             cur += tmp;
 5|             return cur;
 5|         };
-5|     })();
+5|     })()
 5| };
 5|
 5| var n;

--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,7 @@ order to produce sequence of values (either finite or infinite).</div>
     <div class="arrow"><i class="fa fa-caret-up"></i><i class="fa fa-caret-down"></i></div><div class="js es5">
     <div class="title"><b>ECMAScript 5</b> &mdash; syntactic sugar: <span class="style reduced">reduced</span> | <span class="style traditional">traditional</span></div>
     <div class="code"><span class="keyword">var</span> fibonacci<span class="punctuation"> = </span><span class="punctuation">{</span>
-    next: <span class="punctuation">(</span><span class="punctuation">(</span><span class="mark"><span class="keyword">function</span></span> <span class="punctuation">(</span><span class="punctuation">)</span> <span class="punctuation">{</span>
+    next: <span class="punctuation">(</span><span class="mark"><span class="keyword">function</span></span> <span class="punctuation">(</span><span class="punctuation">)</span> <span class="punctuation">{</span>
         <span class="keyword">var</span> pre<span class="punctuation"> = </span><span class="literal">0</span><span class="punctuation">,</span> cur<span class="punctuation"> = </span><span class="literal">1</span><span class="semi">;</span>
         <span class="keyword">return</span> <span class="keyword">function</span> <span class="punctuation">(</span><span class="punctuation">)</span> <span class="punctuation">{</span>
             tmp<span class="punctuation"> = </span>pre<span class="semi">;</span>
@@ -1477,7 +1477,7 @@ order to produce sequence of values (either finite or infinite).</div>
             cur <span class="punctuation">+</span>= tmp<span class="semi">;</span>
             <span class="keyword">return</span> cur<span class="semi">;</span>
         <span class="punctuation">}</span><span class="semi">;</span>
-    <span class="punctuation">}</span><span class="punctuation">)</span><span class="punctuation">(</span><span class="punctuation">)</span><span class="semi">;</span>
+    <span class="punctuation">}</span><span class="punctuation">)</span><span class="punctuation">(</span><span class="punctuation">)</span>
 <span class="punctuation">}</span><span class="semi">;</span>
 
 <span class="keyword">var</span> n<span class="semi">;</span>


### PR DESCRIPTION
There's an extra parenthesis and semicolon that would generate a SyntaxError
if one would try to run the ES5 example
