### PR TITLE
Pass `this` as the `thisArg` to `forEach` instead of `bind`

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -170,11 +170,11 @@ More intuitive handling of current object context.
 5|         |self|.fives.push(v);
 5| });
 5|
-5| //  variant 2 (since ECMAScript 5.1 only)
+5| //  variant 2
 5| |this|.nums.forEach(|function (v)| {
 5|     if (v % 5 === 0)
 5|         |this|.fives.push(v);
-5| }|.bind(this)|);
+5| }, |this|);
 
 
 Extended Parameter Handling

--- a/index.html
+++ b/index.html
@@ -453,11 +453,11 @@ nums <span class="punctuation"> = </span>evens<span class="punctuation">.</span>
         <span class="mark">self</span><span class="punctuation">.</span>fives<span class="punctuation">.</span>push<span class="punctuation">(</span>v<span class="punctuation">)</span><span class="semi">;</span>
 <span class="punctuation">}</span><span class="punctuation">)</span><span class="semi">;</span>
 <span class="comment">
-//  variant <span class="literal">2</span> <span class="punctuation">(</span>since ECMAScript <span class="literal">5</span><span class="punctuation">.</span><span class="literal">1</span> only<span class="punctuation">)</span></span>
+//  variant <span class="literal">2</span></span>
 <span class="mark"><span class="keyword">this</span></span><span class="punctuation">.</span>nums<span class="punctuation">.</span>forEach<span class="punctuation">(</span><span class="mark"><span class="keyword">function</span> <span class="punctuation">(</span>v<span class="punctuation">)</span></span> <span class="punctuation">{</span>
     <span class="keyword">if</span> <span class="punctuation">(</span>v <span class="punctuation">%</span> <span class="literal">5</span> <span class="punctuation">===</span> <span class="literal">0</span><span class="punctuation">)</span>
         <span class="mark"><span class="keyword">this</span></span><span class="punctuation">.</span>fives<span class="punctuation">.</span>push<span class="punctuation">(</span>v<span class="punctuation">)</span><span class="semi">;</span>
-<span class="punctuation">}</span><span class="mark"><span class="punctuation">.</span>bind<span class="punctuation">(</span><span class="keyword">this</span><span class="punctuation">)</span></span><span class="punctuation">)</span><span class="semi">;</span></div>
+<span class="punctuation">}</span><span class="punctuation">,</span> <span class="mark"><span class="keyword">this</span></span><span class="punctuation">)</span><span class="semi">;</span></div>
     <i class="icon fa fa-circle"></i>
     <i class="icon fa fa-times-circle"></i>
 </div>


### PR DESCRIPTION
The second argument to `Array.prototype.forEach` can be used to set the `this` value for the callback function. This is really handy and avoids the explicit use of `bind`.

``` js
> var me = {
... fives: [],
... nums: Array.apply(null, Array(200)).map(function (_, i) { return i; }),
... fillFives: function () {
..... this.nums.forEach(function (num) {
....... if (num % 5 === 0) {
......... this.fives.push(num);
......... }
....... }, this);
..... }
... };

> me.fives;
[]
> me.fillFives();

> me.fives;
[ 0,
  5,
  10,
  15,
  20,
  25,
  30,
  35,
  40,
  45,
  50,
  55,
  60,
  65,
  70,
  75,
  80,
  85,
  90,
  95,
  100,
  105,
  110,
  115,
  120,
  125,
  130,
  135,
  140,
  145,
  150,
  155,
  160,
  165,
  170,
  175,
  180,
  185,
  190,
  195 ]
>
```
