### PR TITLE
Fixing Z-index issue with ES5 and ES6 Icons

### DIFF
--- a/index.css
+++ b/index.css
@@ -354,21 +354,20 @@ code {
     color: #999999;
 }
 .content .js .icon {
+    z-index: 999;
     position: absolute;
     top: 5px;
     right: 5px;
     font-size: 30px;
 }
 .content .js.es5 .icon {
-    z-index: 1001;
     color: #990000;
 }
 .content .js.es6 .icon {
-    z-index: 1001;
     color: #009900;
 }
 .content .js .icon.fa-circle {
-    z-index: 1000;
+    z-index: 999;
     color: #ffffff;
 }
 


### PR DESCRIPTION
Reduced Z-index to 999 for fa-circle and js.es5 and js.es6 icons

Below are the two issues can be fixed by this pull request.

![tick](https://cloud.githubusercontent.com/assets/1652629/12318131/f30037c0-babd-11e5-921e-982aedc2aa2e.png)
![cross](https://cloud.githubusercontent.com/assets/1652629/12318132/f30084c8-babd-11e5-9c83-bcb3b39dade8.png)
