### PR TITLE
Symbol doesn't have a new constructor.

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -1259,7 +1259,7 @@ Map Data-Structure
 Cleaner data-structure for common algorithms based on maps.
 
 6| let m = |new Map()|;
-6| let s = |new Symbol()|;
+6| let s = |Symbol()|;
 6| m.|set("hello", 42)|;
 6| m.|set(s, 34)|;
 6| m.|get(s)| === 34;


### PR DESCRIPTION
The Symbol() function returns a value of type symbol, has static properties that expose several members of built-in objects, has static methods that expose the global symbol registry, and resembles a built-in object class but is incomplete as a constructor because it does not support the syntax "new Symbol()".

source: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Symbol