### PR TITLE
Fix uncaught type error on clicking lexical this

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@
         $(".showcase").css("display", "none")
         $(".showcase:first").css("display", "block")
         $("li.subtitle:first").addClass("selected")
-        $(".nav a").click(function (ev) {
-            var id = $(ev.target).attr("href").replace(/^#/, "")
+        $(".nav a").click(function () {
+            var id = $(this).attr("href").replace(/^#/, "")
             $(".showcase").css("display", "none")
             $(".showcase_" + id).css("display", "block")
             $("li.subtitle").removeClass("selected")


### PR DESCRIPTION
Thank you for nice documents about ES6 features.

I found a slight issue on clicking 'Lexical this' in side menu, please see the following image.

<img width="1076" alt="problem" src="https://cloud.githubusercontent.com/assets/3458295/26754290/d63e7b68-48b2-11e7-8e4c-76260cdb75d0.png">

When 'Lexical this' link is clicked, the `ev.target` does not contain `<a>` tag element, but `<code>` tag element under `<a>` tag. And `<code>` tag does not have `href` attribute, so error is occurred.

I fixed this issue by using `$(this)` instead of `$(ev.target)`. Also the argument `ev` is not used, so I removed it.