### PR TITLE
Convert Symbol to string for demo purposes

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -1274,7 +1274,7 @@ Cleaner data-structure for common algorithms based on maps.
 6| m.|get(s)| === 34;
 6| m.|size| === 2;
 6| for (let |[ key, val ] of m.entries()|)
-6|     console.log(key + " = " + val);
+6|     console.log(key.toString() + " = " + val);
 
 5| var m = |{}|;
 5| // no equivalent in ES5


### PR DESCRIPTION
It's necessary convert to string the current `Symbol` in `console.log` function.

```diff
let m = new Map()
let s = Symbol()
m.set("hello", 42)
m.set(s, 34)
m.get(s) === 34
m.size === 2
for (let [ key, val ] of m.entries())
-   console.log(key + " = " + val)
+   console.log(key.toString() + " = " + val)
```

The above avoid the following error: 
```
Uncaught TypeError: Cannot convert a Symbol value to a string
```