### PR TITLE
Regular Expression Sticky Matching doesn't work

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -363,10 +363,10 @@ even with an arbitrary number of distinct regular expressions.
 6|     console.log(JSON.stringify(match));
 6| };
 6| parser("Foo 1 Bar 7 Baz 42", [
-6|     { pattern: /^Foo\s+(\d+)/|y|, action: (match) => report(match) },
-6|     { pattern: /^Bar\s+(\d+)/|y|, action: (match) => report(match) },
-6|     { pattern: /^Baz\s+(\d+)/|y|, action: (match) => report(match) },
-6|     { pattern: /^\s*/|y|,         action: (match) => {}            }
+6|     { pattern: /Foo\s+(\d+)/|y|, action: (match) => report(match) },
+6|     { pattern: /Bar\s+(\d+)/|y|, action: (match) => report(match) },
+6|     { pattern: /Baz\s+(\d+)/|y|, action: (match) => report(match) },
+6|     { pattern: /\s*/|y|,         action: (match) => {}            }
 6| ]);
 
 5| var parser = function (input, match) {


### PR DESCRIPTION
Tested on node v6.10.0 the patterns don't work if they have a beginning of string matcher (^)