### PR TITLE
Inheritance with regarding static method

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -682,12 +682,14 @@ More intuitive, OOP-style and boilerplate-free inheritance.
 5| };
 5| |Rectangle.prototype = Object.create(Shape.prototype)|;
 5| |Rectangle.prototype.constructor = Rectangle|;
+5| |Rectangle.__proto__ = Shape|;
 5| var Circle = function (id, x, y, radius) {
 5|     |Shape.call|(this, id, x, y);
 5|     this.radius = radius;
 5| };
 5| |Circle.prototype = Object.create(Shape.prototype)|;
 5| |Circle.prototype.constructor = Circle|;
+5| |Circle.__proto__ = Shape|;
 
 Class Inheritance, From Expressions
 -----------------------------------


### PR DESCRIPTION
To inherit static method of the parent class, in es5, the child function's prototype link called `__proto__` should be assigned as parent function itself. For example,
```js
function Parent(){}
function Child(){}

Parent.sayHello = function(){
    console.log("hello");
}

Child.prototype = Object.create(Parent.prototype)
Child.prototype.constructor = Child

Child.sayHello() // Error

```


In the case of es6, 
```js
class Parent{
    static sayHello(){
        console.log("hello")
    }
}
class Child extends Parent{}
Child.sayHello() // "hello"
```

To solve this problem, the prototype link called `__proto__` of `Child` should be defined as `Parent` .
```js
function Parent(){}
function Child(){}

Parent.sayHello = function(){
    console.log("hello");
}

Child.prototype = Object.create(Parent.prototype)
Child.prototype.constructor = Child
Child.__proto__ = Parent
Child.sayHello() // Error

```
