### PR TITLE
The result of Array Matching is wrong

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -461,7 +461,7 @@ Intuitive and flexible destructuring of Arrays into individual variables during 
 
 6| var list = [ 1, 2, 3 ];
 6| var |[ a, , b ] = list|;
-6| [ |b, a| ] = [ |a, b| ];
+6| {[ |b, a| ] = [ |a, b| ]};
 
 5| var list = [ 1, 2, 3 ];
 5| var |a = list[0]|, |b = list[2]|;

--- a/index.html
+++ b/index.html
@@ -824,7 +824,7 @@ for both regular functions and generator functions.</div>
     <div class="title"><b>ECMAScript 6</b> &mdash; syntactic sugar: <span class="style reduced">reduced</span> | <span class="style traditional">traditional</span></div>
     <div class="code"><span class="keyword">var</span> list<span class="punctuation"> = </span><span class="punctuation">[</span> <span class="literal">1</span><span class="punctuation">,</span> <span class="literal">2</span><span class="punctuation">,</span> <span class="literal">3</span> <span class="punctuation">]</span><span class="semi">;</span>
 <span class="keyword">var</span> <span class="mark"><span class="punctuation">[</span> a<span class="punctuation">,</span> <span class="punctuation">,</span> b <span class="punctuation">]</span><span class="punctuation"> = </span>list</span><span class="semi">;</span>
-<span class="punctuation">[</span> <span class="mark">b<span class="punctuation">,</span> a</span> <span class="punctuation">]</span><span class="punctuation"> = </span><span class="punctuation">[</span> <span class="mark">a<span class="punctuation">,</span> b</span> <span class="punctuation">]</span><span class="semi">;</span>
+<span class="punctuation">{</span><span class="punctuation">[</span> <span class="mark">b<span class="punctuation">,</span> a</span> <span class="punctuation">]</span><span class="punctuation"> = </span><span class="punctuation">[</span> <span class="mark">a<span class="punctuation">,</span> b</span> <span class="punctuation">]</span><span class="punctuation">}</span><span class="semi">;</span>
 </div>
     <i class="icon fa fa-circle"></i>
     <i class="icon fa fa-check-circle"></i>


### PR DESCRIPTION
The result from ES6 Array Matching is not what it is expected to be with syntactic sugar which is the default.
```
var list = [ 1, 2, 3 ]
var [ a, , b ] = list
[ b, a ] = [ a, b ]
```
The result is supposed to be a is 3 and b is 1, but due to the syntactic sugar, a and b are all undefined.
That is because the code will be like 
```
var [ a, , b ] = list[ b, a ] = [ a, b ]
```
Therefore, I just put square brackets for the last sentence.