### PR TITLE
domain es6-features.org is not working

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-es6-features.org
+


### PR DESCRIPTION
the domain es6-features.org is not working
so removing it from CNAME in order to make the github pages url (https://rse.github.io/es6-features/#ClassDefinition) functional